### PR TITLE
Fix compilation with Erlang/OTP 26

### DIFF
--- a/.github/workflows/erlang-ci.yml
+++ b/.github/workflows/erlang-ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]
-        otp-version: [21.3, 22.3, 23.2]
+        otp-version: [21.3, 22.3, 23.3, 24.3, 25.3, 26]
 
     runs-on: ${{ matrix.platform }}
 

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -9,7 +9,7 @@ BASEDIR := $(abspath $(CURDIR)/..)
 PROJECT ?= $(notdir $(BASEDIR))
 PROJECT := $(strip $(PROJECT))
 
-ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)]).")
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -eval "io:format(\"~ts/erts-~ts/include/\", [code:root_dir(), erlang:system_info(version)])." -s erlang halt)
 
 C_SRC_DIR = $(CURDIR)
 C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so


### PR DESCRIPTION
ecaptcha compiles perfectly with Erlang/OTP 21.3 up to 25.3

However, compilation fails with Erlang/OTP 26.0:
```
find src/*_opt.erl -type f \! -regex ".*git.*" -exec sed -i 's/re:mp/  tuple/g' {} \;
/usr/local/lib/erlang/bin/escript ./rebar3 dialyzer
===> Analyzing applications...
===> Compiling configure_deps
===> Verifying dependencies...
make[1]: Entering directory '/__w/ejabberd-contrib/ejabberd-contrib/_build/default/lib/ecaptcha/c_src'
Error! Failed to eval: io:format("~ts/erts-~ts/include/", [code:root_dir(), erlang:system_info(version)]).

cc -O3 -std=c[9](https://github.com/badlop/ejabberd-contrib/actions/runs/5246088007/jobs/9474435672#step:22:10)9 -finline-functions -Wall -Wmissing-prototypes -fPIC -I   -c -o /__w/ejabberd-contrib/ejabberd-contrib/_build/default/lib/ecaptcha/c_src/ecaptcha_nif.o /__w/ejabberd-contrib/ejabberd-contrib/_build/default/lib/ecaptcha/c_src/ecaptcha_nif.c
/__w/ejabberd-contrib/ejabberd-contrib/_build/default/lib/ecaptcha/c_src/ecaptcha_nif.c:4:[10](https://github.com/badlop/ejabberd-contrib/actions/runs/5246088007/jobs/9474435672#step:22:11): fatal error: erl_nif.h: No such file or directory
    4 | #include "erl_nif.h"
      |          ^~~~~~~~~~~
```

Apparently, Erlang 26 requires "-s init stop" to be at the end of the line. In fact, let's use "erlang halt", as seen in an example in   https://www.erlang.org/doc/man/init.html#command-line-flags which stops faster.

This patch is being tested and [works correctly](https://github.com/processone/ejabberd-contrib/actions/runs/5247391429) in Erlang/OTP 21.3, 25.3 and 26.0, as seen in that repository which uses ecaptcha as a dependency.